### PR TITLE
Fix the docs build: escape Liquid interpolation in inline code spans

### DIFF
--- a/docs/assets/cart.md
+++ b/docs/assets/cart.md
@@ -9,7 +9,7 @@
 ## What It Does
 
 - Exposes a global API: `window.Cart = { state, add, change, update, refresh }`.
-- Reads initial cart state from `<script type="application/json" id="cart-data">{{ cart | json }}</script>` in `layout/theme.liquid`.
+- Reads initial cart state from <code v-pre>&lt;script type="application/json" id="cart-data"&gt;{{ cart | json }}&lt;/script&gt;</code> in `layout/theme.liquid`.
 - Serializes every mutation through a promise queue so rapid clicks can't race; while requests are in flight, `<html>` gets a `cart-busy` class (`cart.css` dims `.cart-items`).
 - Bundles Section Rendering API HTML into every mutation via the `sections` request param — section ids are read from the DOM (`closest('.shopify-section')`) for any `<cart-drawer>` / `<cart-page>` elements present, nothing is hardcoded.
 - Dispatches `cart:change` on success and `cart:error` on failure (both on `document`).

--- a/docs/assets/component-cart-drawer.md
+++ b/docs/assets/component-cart-drawer.md
@@ -57,7 +57,7 @@ onDocumentClick(event) {
 }
 ```
 
-- The header cart bubble is a plain `<a href="{{ routes.cart_url }}">`; with JS active the drawer intercepts it, without JS the link still navigates to the cart page.
+- The header cart bubble is a plain <code v-pre>&lt;a href="{{ routes.cart_url }}"&gt;</code>; with JS active the drawer intercepts it, without JS the link still navigates to the cart page.
 
 ### onInnerClick(event)
 

--- a/docs/sections/featured-products.md
+++ b/docs/sections/featured-products.md
@@ -44,7 +44,7 @@ The section uses CSS custom properties set via a `<style>` block and inline styl
 
 - CSS variables set for button colors, alignment options, and stars color.
 - Inline styles applied to stars, product titles, and prices with fallback defaults.
-- Alignment classes applied via CSS variable: `product-card__info--{{ product_content_alignment }}` and `product-card__reviews--{{ review_content_alignment }}`.
+- Alignment classes applied via CSS variable: <code v-pre>product-card__info--{{ product_content_alignment }}</code> and <code v-pre>product-card__reviews--{{ review_content_alignment }}</code>.
 
 ---
 
@@ -100,7 +100,7 @@ The section uses CSS custom properties set via a `<style>` block and inline styl
 </div>
 ```
 
-- Heading alignment controlled via CSS class: `featured-products__titles--{{ heading_alignment }}`.
+- Heading alignment controlled via CSS class: <code v-pre>featured-products__titles--{{ heading_alignment }}</code>.
 - "View All" link appears as text link when `show_view_all_as_button` is false.
 
 ### Swiper Carousel

--- a/docs/sections/shop-the-look.md
+++ b/docs/sections/shop-the-look.md
@@ -164,7 +164,7 @@ The `section-shop-the-look.js` custom element:
 ### CSS Variables Used
 - `--color-background`: Background colors
 - `--color-foreground`: Text and border colors
-- Theme color scheme variables via `color-{{ color_scheme }}` class
+- Theme color scheme variables via <code v-pre>color-{{ color_scheme }}</code> class
 
 ### Key CSS Features
 - CSS Grid for responsive layouts

--- a/docs/snippets/component-cart-notification.md
+++ b/docs/snippets/component-cart-notification.md
@@ -18,7 +18,7 @@
 
 | Parameter            | Type     | Default  | Description                                                                 |
 |----------------------|----------|----------|-----------------------------------------------------------------------------|
-| `color_scheme`       | string   | `nil`    | When provided, adds `color-{{ color_scheme }} gradient` to the drawer.      |
+| `color_scheme`       | string   | `nil`    | When provided, adds <code v-pre>color-{{ color_scheme }} gradient</code> to the drawer.      |
 | `desktop_menu_type`  | string   | `blank`  | Determines layout wrapper; non-`drawer` adds the `page-width` utility class.|
 
 > The snippet uses LiquidDoc style comments to describe these params inline.

--- a/docs/snippets/component-pagination.md
+++ b/docs/snippets/component-pagination.md
@@ -308,7 +308,7 @@ Typically used in:
 
 38. **Icon rotation**: Previous button icon should be rotated 180° via CSS to point left instead of right.
 
-39. **Spacing**: Icon has space before it in next button (`<span class="svg-wrapper"> {{ 'icon-caret.svg' | inline_asset_content }}</span>`) but not in previous button - this may be intentional or a minor inconsistency.
+39. **Spacing**: Icon has space before it in next button (<code v-pre>&lt;span class="svg-wrapper"&gt; {{ 'icon-caret.svg' | inline_asset_content }}&lt;/span&gt;</code>) but not in previous button - this may be intentional or a minor inconsistency.
 
 40. **Translation file structure**: Translation keys should be structured in `locales/en.default.json`:
     ```json


### PR DESCRIPTION
## What

`npm run build` in `docs/` has been failing with:

```
build error:
Cannot read properties of undefined (reading 'cart_url')
```

VitePress compiles markdown as a Vue template. It applies `v-pre` to **fenced** code blocks automatically, but **not** to inline code spans — so `` `{{ routes.cart_url }}` `` inside backticks is evaluated as a Vue expression against an undefined `routes`, and page rendering dies.

Seven inline code spans across six files were affected. Each becomes a `<code v-pre>` element with its angle brackets escaped — renders identically, and Vue no longer compiles the contents.

| File | Line |
|---|---|
| `docs/assets/cart.md` | 12 |
| `docs/assets/component-cart-drawer.md` | 60 |
| `docs/sections/featured-products.md` | 47, 103 |
| `docs/sections/shop-the-look.md` | 167 |
| `docs/snippets/component-cart-notification.md` | 21 |
| `docs/snippets/component-pagination.md` | 311 |

## Why now

`.github/workflows/deploy-docs.yml` runs on pushes to `development` touching `docs/**`. The last such change was **2026-06-10**, so the workflow hasn't run since the breakage and nobody saw it go red.

This is being fixed on its own branch deliberately: a separate branch adding documentation would otherwise have triggered the workflow and looked like the cause.

## Verification

Built `origin/development` in a clean worktree with none of these changes — **same failure**, confirming it predates this branch. Built again after the fix:

```
✓ building client + server bundles...
✓ rendering pages...
build complete in 3.21s.
```

## Scope

Six markdown files under `docs/`. No theme code, no config, no workflow changes.