### PR TITLE
Add a parallel section-build workflow, and fix two rules that taught the wrong convention

### DIFF
--- a/.claude/rules/sections.md
+++ b/.claude/rules/sections.md
@@ -121,6 +121,23 @@ for `{% stylesheet %}`) and **load JS as `type="module"`** (Base: 40 uses, zero
 {% endschema %}
 ```
 
+> **The `750px` above is the padding boilerplate's breakpoint, not the theme's
+> layout breakpoint.** Keep it — it is inherited from Dawn and 31 sections here
+> already use it, so changing it in one section desynchronises that section's mobile
+> padding from every other. Your own component CSS is a separate decision: Base's
+> `section-*.css` is split evenly between `750px` and `769px`, so **in a client theme
+> forked from Base, grep `assets/` and match whatever that theme settled on** rather
+> than copying a number out of this file. Two numbers, two jobs — don't unify them.
+
+> **`.page-width` is correct in Base and may not be in the theme you are working in.**
+> Base uses it in all 32 of its sections. A client theme often introduces its own
+> container with a different max-width, and the two are frequently **identical at
+> 1440** — so a section built and measured only at 1440 passes review and then reads
+> as broken on a large screen. This happened on a client build and was caught by the
+> lead, not by the developer. Check which container class that theme's finished,
+> QI-passed pages use, and measure at 1920 and 393 as well as at the width the Figma
+> frame was drawn at.
+
 The four `t:` keys above all resolve in `locales/en.default.schema.json` today —
 use them rather than inventing new ones. Note that the mobile padding is
 three-quarters of the desktop value; that scaling is part of the pattern, not

--- a/.claude/rules/snippets.md
+++ b/.claude/rules/snippets.md
@@ -8,7 +8,15 @@ paths:
 
 ## Snippet Documentation
 
-Every snippet must include JSDoc-style comments using LiquidDoc:
+Every snippet must include a `{% doc %}` block using LiquidDoc.
+
+**The type comes before the name, in braces, and a dash separates the
+description:** `@param {type} name - description`. Optional params wrap the name
+in square brackets. Every one of this theme's 45 declarations uses this form, and it is
+what Shopify's `ValidDocParamTypes` check validates — the JSDoc-style
+`@param name {Type} description` reads fine to a human and is silently skipped by
+the checker, so a snippet documented that way has no validated parameter coverage
+at all.
 
 ```liquid
 {% doc %}
@@ -16,12 +24,12 @@ Every snippet must include JSDoc-style comments using LiquidDoc:
 
   Renders a product card with customizable options.
 
-  @param product {Object} Product object (required)
-  @param show_vendor {Boolean} Display vendor name (default: false)
-  @param show_quick_add {Boolean} Show quick add button (default: false)
-  @param image_ratio {String} Image aspect ratio (default: 'adapt')
-  @param lazy_load {Boolean} Enable lazy loading (default: true)
-  @param card_class {String} Additional CSS classes
+  @param {product} product - Product object
+  @param {boolean} [show_vendor] - Display vendor name (default: false)
+  @param {boolean} [show_quick_add] - Show quick add button (default: false)
+  @param {string} [image_ratio] - Image aspect ratio (default: 'adapt')
+  @param {boolean} [lazy_load] - Enable lazy loading (default: true)
+  @param {string} [card_class] - Additional CSS classes
 
   @example
     {% render 'product-card',
@@ -58,11 +66,11 @@ Always provide defaults and validate parameters:
 
 **Icon Snippet:**
 ```liquid
-{% comment %}
-  @param icon {String} Icon name (required)
-  @param size {String} Icon size class (default: 'icon--medium')
-  @param class {String} Additional classes
-{% endcomment %}
+{% doc %}
+  @param {string} icon - Icon name
+  @param {string} [size] - Icon size class (default: 'icon--medium')
+  @param {string} [class] - Additional classes
+{% enddoc %}
 
 {% liquid
   assign icon = icon | default: ''
@@ -81,11 +89,11 @@ Always provide defaults and validate parameters:
 
 **Price Snippet:**
 ```liquid
-{% comment %}
-  @param product {Object} Product object (required)
-  @param show_compare_at {Boolean} Show compare at price (default: true)
-  @param show_unit_price {Boolean} Show unit price (default: false)
-{% endcomment %}
+{% doc %}
+  @param {product} product - Product object
+  @param {boolean} [show_compare_at] - Show compare at price (default: true)
+  @param {boolean} [show_unit_price] - Show unit price (default: false)
+{% enddoc %}
 
 {% liquid
   assign show_compare_at = show_compare_at | default: true

--- a/.claude/scripts/merge-locale-fragments.py
+++ b/.claude/scripts/merge-locale-fragments.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Merge agent locale fragments into the two locale files.
+
+Agents cannot write locales/*.json concurrently without corrupting them, so each
+writes {"schema": {...}, "storefront": {...}} to a fragment. This merges every
+fragment present, refusing to overwrite an existing key.
+
+Usage: python3 .claude/scripts/merge-locale-fragments.py <fragment-dir>
+"""
+import json, re, pathlib, subprocess, sys
+
+if len(sys.argv) != 2:
+    sys.exit("usage: merge-locale-fragments.py <fragment-dir>")
+
+SP = pathlib.Path(sys.argv[1]).expanduser()
+if not SP.is_dir():
+    sys.exit(f"not a directory: {SP}")
+
+# Resolve the repo from git rather than a hardcoded path, so this script is
+# portable between the client themes forked from Base.
+REPO = pathlib.Path(
+    subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        capture_output=True, text=True, check=True,
+    ).stdout.strip()
+)
+
+def load(p):
+    raw = p.read_text()
+    m = re.match(r'^\s*/\*.*?\*/\s*', raw, re.S)
+    header = m.group(0) if m else ''
+    return header, json.loads(raw[len(header):])
+
+def deep_merge(dst, src, path, conflicts):
+    for k, v in src.items():
+        if isinstance(v, dict):
+            if k in dst and not isinstance(dst[k], dict):
+                conflicts.append(f"{path}.{k} (type clash)"); continue
+            deep_merge(dst.setdefault(k, {}), v, f"{path}.{k}", conflicts)
+        else:
+            if k in dst and dst[k] != v:
+                conflicts.append(f"{path}.{k}: existing {dst[k]!r} kept, fragment wanted {v!r}")
+            else:
+                dst[k] = v
+
+frags = sorted(SP.glob("*.json"))
+if not frags:
+    print("no fragments yet"); sys.exit(0)
+
+targets = {
+    "schema":     REPO / "locales/en.default.schema.json",
+    "storefront": REPO / "locales/en.default.json",
+}
+loaded = {k: load(p) for k, p in targets.items()}
+conflicts, added = [], {k: 0 for k in targets}
+
+def count_leaves(d):
+    return sum(count_leaves(v) if isinstance(v, dict) else 1 for v in d.values())
+
+for f in frags:
+    frag = json.loads(f.read_text())
+    for key in targets:
+        block = frag.get(key) or {}
+        if block:
+            added[key] += count_leaves(block)
+            deep_merge(loaded[key][1], block, key, conflicts)
+    print(f"  merged {f.name}")
+
+for key, path in targets.items():
+    header, data = loaded[key]
+    path.write_text(header + json.dumps(data, indent=2, ensure_ascii=False) + "\n")
+    print(f"{path.name}: +{added[key]} keys")
+
+if conflicts:
+    print("\nCONFLICTS (existing values kept):")
+    for c in conflicts: print("  -", c)

--- a/.claude/workflows/parallel-section-build.md
+++ b/.claude/workflows/parallel-section-build.md
@@ -1,0 +1,256 @@
+# Workflow — building a page's sections with parallel agents
+
+Build one page of a Figma design by giving each section to its own agent, running
+them concurrently, then assembling and verifying the page yourself.
+
+Used on the BPN PDP: 9 sections, ~1.5 hours wall-clock, reviewed by the team lead as
+"could be more than 60%" saved against a 40-hour estimate. This file is what made
+that repeatable rather than lucky. It is not a skill — skills only run when invoked,
+and this is a procedure a human chooses to start.
+
+**When to use it.** A page of 5+ independent content sections, each traceable to its
+own Figma frame. **When not to:** anything where the sections share a stylesheet or a
+JS module, or where section B's markup depends on section A's. Concurrency buys
+nothing there and costs you a merge.
+
+---
+
+## Part 1 — Orchestrator (you)
+
+### 1. Establish the section list before spawning anything
+
+Enumerate the page's sections from the desktop frame, top to bottom, and for each one
+record the **desktop node id and the mobile node id**. One agent per row.
+
+Then — and this is the step that is skipped and always costs the most — **check what
+already exists.** A section that another page already ships is a `templates/*.json`
+entry, not a build. Grep `sections/`, and read whatever estimate or scope doc the
+lead has written. On BPN, seven of the PDP's sections had already been delivered by
+the homepage build.
+
+Do not trust a name match. "Collections strip → Shop By Goal cards" looked like the
+same component in a scope doc and was not remotely the same component. Open both and
+look.
+
+### 2. Fill in the agent brief
+
+Copy Part 2 below into the scratchpad, fill the four placeholders at the top, and
+hand every agent the same file. One brief, N agents — divergent briefs produce
+divergent conventions, which you then pay for at assembly.
+
+### 3. Spawn, then stay out of the way
+
+One agent per section, all in a single message so they run concurrently. Give each
+one only its own two node ids and its own file ownership list.
+
+### 4. Assemble
+
+- Merge the locale fragments: `python3 .claude/scripts/merge-locale-fragments.py <fragment-dir>`
+  It refuses to overwrite an existing key and reports every conflict, which is the
+  whole reason agents write fragments instead of touching `locales/` directly.
+- Build `templates/<page>.json` from the section presets, in frame order.
+- **Strip `t:` values.** Shopify resolves `t:` keys in a schema `default`, but *not*
+  in values stored in a template. A `t:` left in a template renders the key path to
+  the customer.
+- A brand-new block type needs roughly 25 seconds to register with Shopify before a
+  template may reference it. Reference it too early and every route on the theme
+  returns 500.
+
+### 5. Verify — and read this before you report anything
+
+Agents report their own fidelity. Two of three "X is broken" reports on the BPN build
+were false, both from agents measuring inside their own static harness rather than in
+the theme. Re-verify anything load-bearing yourself.
+
+**Matching heights is not matching the design.** The single worst failure of this
+workflow to date: a section was reported as built because it measured 614px against
+the frame's 615px, and a scope doc independently agreed. It shared nothing else with
+the design. A FAQ layout was reported as matching at 728 vs 727 while its media
+column was rendering completely empty.
+
+So: **screenshot both breakpoints and look at them, against the Figma frame.** A
+measurement is a check on a screenshot, never a substitute for one. If you could not
+get a usable screenshot, the honest report is "unverified" — not the number you did
+manage to measure.
+
+### 6. Gate
+
+Run `shopify-standards-coach` for the advisory pass and `shopify-pr-reviewer` over the
+whole diff before it goes to a human.
+
+---
+
+## Part 2 — Agent brief template
+
+Fill in `{{REPO}}`, `{{BRANCH}}`, `{{FIGMA_FILE_KEY}}`, `{{FRAGMENT_DIR}}`,
+`{{PREVIEW_URL}}`, then give this to every agent verbatim.
+
+---
+
+Repo: `{{REPO}}`
+Branch: `{{BRANCH}}` (already checked out — do not switch branches)
+
+You are building **one section** of a page from Figma. Other agents are building the
+other sections in parallel. Stay strictly inside the files you own.
+
+### 1. Read these before writing any code
+
+- `CLAUDE.md`
+- `.claude/rules/sections.md` — the merchant settings contract
+- `.claude/rules/schemas.md`, `css-standards.md`, `localization.md`,
+  `naming-conventions.md`, `html-standards.md`, `liquid.md`
+- `.claude/skills/scaffold-section/SKILL.md` — follow its steps and its self-check
+- `.claude/skills/scaffold-section/reference-section.liquid` — the structural template
+
+Do **not** use `.cursor/rules/examples/section-example.liquid`. It predates the standard.
+
+### 2. Get the design — two frames, separately
+
+Invoke the Figma design-to-code skill **before** your first `get_design_context` call.
+Then call it twice, once per frame:
+
+```
+get_design_context
+  fileKey: {{FIGMA_FILE_KEY}}
+  nodeId: <your DESKTOP node>
+  clientLanguages: liquid,html,css
+  clientFrameworks: shopify-liquid
+```
+
+- Desktop frames are designed at **1440**, mobile at **393**.
+- These are two designs, not one responsive artifact. Mobile frequently uses a
+  different layout and sometimes a different component entirely.
+- Read real values — spacing, type size, line height, colour, radii — off the design.
+  Do not approximate by eye.
+- The returned code is React + Tailwind. **Reference only.** Convert it.
+- Icons and images come back as asset URLs. Never hand-author SVG path data. Download
+  what you need into `assets/` (flat directory, unique filename).
+
+**Figma is design-only.** It never supplies real data. Prices, review counts, ratings,
+stock, product copy, ingredient values all come from Shopify objects, settings or
+metafields. A mock reading "4.9 (127 reviews)" is a picture of a number, not the number.
+**Never invent a fallback value.** Name what has no source and say what you wired it to.
+
+Some frames legitimately contain placeholder copy. If yours does, say so rather than
+shipping lorem ipsum as though it were content.
+
+### 3. Design tokens
+
+Use the theme's existing token layer. **Never write a raw hex.** If your design needs
+a token that does not exist, **do not edit the shared token file** — define a
+component-scoped custom property in your own CSS and report it.
+
+### 4. House conventions
+
+- **px**, not rem.
+- **Mobile-first, `min-width` only**, never `max-width`. Every query includes `screen`.
+  Use the breakpoint this theme's component CSS actually uses — grep `assets/` and
+  match the majority rather than copying a number out of a rule file.
+- **BEM**, and namespace component custom properties: `--<block>-<thing>`.
+- **Logical properties**: `padding-block`, `padding-inline`, `inline-size`, `inset`.
+- **Max selector specificity 0 4 0.**
+- CSS via `{{ 'section-<name>.css' | asset_url | stylesheet_tag }}`; JS, only if
+  genuinely needed, as `type="module"`.
+- **LiquidDoc form is `@param {type} name - description`** — match the codebase, and
+  grep to confirm before trusting any example.
+- `| escape` on every merchant string, in attributes *and* text nodes.
+- Validate snippet params: early `break` when a required one is blank.
+- Interactive JS only as a custom element behind `if (!customElements.get('x'))`,
+  wiring in `connectedCallback` and **removing every listener** in
+  `disconnectedCallback`. No `DOMContentLoaded`, no jQuery. Alpine and Swiper are
+  already loaded globally — Alpine for ephemeral UI state, Swiper for carousels.
+  Prefer native HTML first: `<details>`, `<dialog>`, `popover`.
+- No commented-out code. No `!important` without a comment saying why.
+- Add nothing that has no reader — no unused tokens, data attributes, or classes.
+- If a comment states a number or a behaviour about this codebase, grep to confirm it
+  before you write it.
+
+**A custom element carrying section styling needs an explicit `display`.** Custom
+elements default to `display: inline`, which paints no background around block children
+and ignores vertical padding — while `getComputedStyle()` still reports both. This looks
+correct in a DOM check and wrong on screen.
+
+### 5. The merchant settings contract — the most-missed rule here
+
+Every section exposes, in this order: `color_scheme`, a padding `header`,
+`padding_top` and `padding_bottom` (`range` 0–100 step 4 default 40), plus a `presets`
+array. Those four `t:` label keys already exist — reuse them.
+
+`padding_top`/`padding_bottom` have **no exceptions**. `color_scheme` may be omitted
+only with a Liquid comment naming the Figma node and saying why the surface is fixed.
+
+A Figma frame shows one spacing value because a frame can only show one. That is not a
+reason to omit the control. Expose everything a merchant would reasonably want to
+change — headings, copy, images, links — and the repeating items as blocks.
+
+A `range` needs **at least 3 steps** between min and max. A 2-step range is accepted by
+Theme Check and then fails the whole theme upload — every route 500, not just the page.
+
+### 6. Locale keys — write a fragment, never edit the locale files
+
+`locales/en.default.json` and `en.default.schema.json` are shared by every agent.
+Editing them concurrently corrupts them. Write your keys to
+`{{FRAGMENT_DIR}}/<your-section>.json`:
+
+```json
+{
+  "schema":     { "sections": { "your_section": { "name": "...", "settings": { "heading": { "label": "..." } } } } },
+  "storefront": { "sections": { "your_section": { "empty": "No items yet" } } }
+}
+```
+
+`schema` merges into `en.default.schema.json` (referenced as `t:`), `storefront` into
+`en.default.json` (referenced as `| t`). Write your code as though the keys resolve.
+
+Note: Shopify resolves `t:` only in `label` / `content` / `info` / `name` / `default`.
+A preset that seeds blocks **cannot** localise their per-block text.
+
+### 7. Liquid traps that take the whole theme down
+
+These are not caught by Theme Check and each one 500s every route:
+
+- An **output tag inside a string literal** — `'{{amount}}'` — is a parse error. Use
+  `{% capture %}` with `{% raw %}`.
+- A **filter chain wrapped inside `{% liquid %}`** parses as an unknown tag. Prettier
+  will reformat code into this shape, so re-check after formatting.
+- **`{% raw %}` inside `{% comment %}`** unbalances the comment.
+
+### 8. Hard boundaries
+
+Do not touch the page's main section, `templates/*.json`, `locales/**`, the shared
+token or font snippets, `config/**`, `.husky/**`, or `.claude/**`. Do not `git add`,
+`commit`, `push`, `checkout`, or `stash` — leave every change unstaged; the developer
+reviews and commits. If you need a file outside your ownership list, **stop and report
+it** rather than expanding scope.
+
+### 9. Verification you can actually do
+
+Your section will not be on the preview page yet — the orchestrator assembles the
+template at the end. So:
+
+- Confirm your Liquid parses:
+  `shopify theme check --config=.theme-check.yml 2>&1 | grep -A3 "<your file>"`
+  If the CLI crashes on startup it is the Node version, not your code — prepend a
+  Node 24+ bin directory to `PATH` (`ls ~/.nvm/versions/node`). A crashed CLI is
+  reported by the pre-commit hook as *skipped*, so it silently proves nothing.
+- Run Prettier: `npx prettier --config .prettierrc.json --write sections/<name>.liquid`
+- Grep your own output for bare English:
+  `grep -nE '"(label|content|info|name)": "[A-Z]' sections/<name>.liquid` and
+  `grep -nE 'aria-label="[A-Za-z]|alt="[A-Za-z]|title="[A-Za-z]' sections/<name>.liquid`
+- Confirm every `t:` and `| t` key you referenced exists in your fragment.
+
+### 10. What to report back
+
+1. Files created or changed, with line counts.
+2. **A fidelity table**: property → Figma value → your CSS value, for the things that
+   matter (container widths, gaps, type sizes, colours, radii), desktop and mobile.
+3. The schema settings and blocks you exposed, and why those and not others.
+4. Anything in the design you could **not** implement, and why. Be specific.
+5. Any real data the design implies that has no Shopify source — name it, say what you
+   wired it to (setting? metafield? left blank?). Never invent a fallback.
+6. The `scaffold-section` self-check, item by item, with actual results — not an
+   assertion that you complied.
+7. **Anything you did not verify.** Say "unverified" rather than reporting the one
+   number you could measure as though it settled the question.
+
+Honesty is worth more than a clean report. If something is half-done, say so.

--- a/.cursor/rules/sections.mdc
+++ b/.cursor/rules/sections.mdc
@@ -5,7 +5,7 @@ alwaysApply: false
 ---
 
 <!-- GENERATED from .claude/rules/sections.md by .claude/scripts/sync-ai-config.sh — do not edit here. -->
-<!-- checksum: 392585332 -->
+<!-- checksum: 856169508 -->
 
 
 # Section Development Standards
@@ -124,6 +124,23 @@ for `{% stylesheet %}`) and **load JS as `type="module"`** (Base: 40 uses, zero
 }
 {% endschema %}
 ```
+
+> **The `750px` above is the padding boilerplate's breakpoint, not the theme's
+> layout breakpoint.** Keep it — it is inherited from Dawn and 31 sections here
+> already use it, so changing it in one section desynchronises that section's mobile
+> padding from every other. Your own component CSS is a separate decision: Base's
+> `section-*.css` is split evenly between `750px` and `769px`, so **in a client theme
+> forked from Base, grep `assets/` and match whatever that theme settled on** rather
+> than copying a number out of this file. Two numbers, two jobs — don't unify them.
+
+> **`.page-width` is correct in Base and may not be in the theme you are working in.**
+> Base uses it in all 32 of its sections. A client theme often introduces its own
+> container with a different max-width, and the two are frequently **identical at
+> 1440** — so a section built and measured only at 1440 passes review and then reads
+> as broken on a large screen. This happened on a client build and was caught by the
+> lead, not by the developer. Check which container class that theme's finished,
+> QI-passed pages use, and measure at 1920 and 393 as well as at the width the Figma
+> frame was drawn at.
 
 The four `t:` keys above all resolve in `locales/en.default.schema.json` today —
 use them rather than inventing new ones. Note that the mobile padding is

--- a/.cursor/rules/snippets.mdc
+++ b/.cursor/rules/snippets.mdc
@@ -5,14 +5,22 @@ alwaysApply: false
 ---
 
 <!-- GENERATED from .claude/rules/snippets.md by .claude/scripts/sync-ai-config.sh — do not edit here. -->
-<!-- checksum: 566320991 -->
+<!-- checksum: 696649334 -->
 
 
 # Snippet Development Standards
 
 ## Snippet Documentation
 
-Every snippet must include JSDoc-style comments using LiquidDoc:
+Every snippet must include a `{% doc %}` block using LiquidDoc.
+
+**The type comes before the name, in braces, and a dash separates the
+description:** `@param {type} name - description`. Optional params wrap the name
+in square brackets. Every one of this theme's 45 declarations uses this form, and it is
+what Shopify's `ValidDocParamTypes` check validates — the JSDoc-style
+`@param name {Type} description` reads fine to a human and is silently skipped by
+the checker, so a snippet documented that way has no validated parameter coverage
+at all.
 
 ```liquid
 {% doc %}
@@ -20,12 +28,12 @@ Every snippet must include JSDoc-style comments using LiquidDoc:
 
   Renders a product card with customizable options.
 
-  @param product {Object} Product object (required)
-  @param show_vendor {Boolean} Display vendor name (default: false)
-  @param show_quick_add {Boolean} Show quick add button (default: false)
-  @param image_ratio {String} Image aspect ratio (default: 'adapt')
-  @param lazy_load {Boolean} Enable lazy loading (default: true)
-  @param card_class {String} Additional CSS classes
+  @param {product} product - Product object
+  @param {boolean} [show_vendor] - Display vendor name (default: false)
+  @param {boolean} [show_quick_add] - Show quick add button (default: false)
+  @param {string} [image_ratio] - Image aspect ratio (default: 'adapt')
+  @param {boolean} [lazy_load] - Enable lazy loading (default: true)
+  @param {string} [card_class] - Additional CSS classes
 
   @example
     {% render 'product-card',
@@ -62,11 +70,11 @@ Always provide defaults and validate parameters:
 
 **Icon Snippet:**
 ```liquid
-{% comment %}
-  @param icon {String} Icon name (required)
-  @param size {String} Icon size class (default: 'icon--medium')
-  @param class {String} Additional classes
-{% endcomment %}
+{% doc %}
+  @param {string} icon - Icon name
+  @param {string} [size] - Icon size class (default: 'icon--medium')
+  @param {string} [class] - Additional classes
+{% enddoc %}
 
 {% liquid
   assign icon = icon | default: ''
@@ -85,11 +93,11 @@ Always provide defaults and validate parameters:
 
 **Price Snippet:**
 ```liquid
-{% comment %}
-  @param product {Object} Product object (required)
-  @param show_compare_at {Boolean} Show compare at price (default: true)
-  @param show_unit_price {Boolean} Show unit price (default: false)
-{% endcomment %}
+{% doc %}
+  @param {product} product - Product object
+  @param {boolean} [show_compare_at] - Show compare at price (default: true)
+  @param {boolean} [show_unit_price] - Show unit price (default: false)
+{% enddoc %}
 
 {% liquid
   assign show_compare_at = show_compare_at | default: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,13 +84,17 @@ The two copies existing by hand is what caused this project's worst failure —
 the conventions sat in `.cursor/rules/` where Claude Code could not read them
 for the first 18 days of a client build. The script makes drift impossible.
 
-## Skills and agents
+## Skills, agents and workflows
 
 - `.claude/skills/` — invoked procedures: building a page from a Figma frame,
   scaffolding a section, closing the QA loop, accessibility review.
 - `.claude/agents/` — review passes with their own context:
   `shopify-standards-coach` (advisory, teaches) and `shopify-pr-reviewer`
   (gates, decides whether something is safe to merge).
+- `.claude/workflows/` — multi-agent procedures a human starts deliberately.
+  `parallel-section-build.md` builds a whole page by giving each section to its
+  own agent, and carries the assembly and verification steps that make that
+  safe. Point an agent at the file; it is not auto-loaded.
 
 Skills only run when invoked. Conventions that must hold unprompted live in
 `.claude/rules/`, not in a skill.


### PR DESCRIPTION
Answers Moemen's question in the BPN thread — *"anything that we need to keep adding to our original base theme for that flow to function better the next time?"* This is that, extracted from the BPN PDP build rather than written speculatively.

## What's here

**`.claude/workflows/` is a new directory.** It's for multi-agent procedures a human starts deliberately — neither a skill (invoked per-task, scoped to one file) nor a rule (must hold unprompted). Not auto-loaded; you point an agent at it.

`parallel-section-build.md` builds one page of a Figma design by giving each section to its own agent. On the BPN PDP that was 9 sections in ~1.5 hours wall-clock, which Khaled assessed as *"could be more than 60%"* saved against a 40-hour estimate. Two parts: an orchestrator procedure, and a fill-in-the-blanks agent brief (`{{REPO}}`, `{{BRANCH}}`, `{{FIGMA_FILE_KEY}}`, `{{FRAGMENT_DIR}}`).

`merge-locale-fragments.py` is what makes the fan-out safe. Agents can't write `locales/*.json` concurrently without corrupting them, so each writes a fragment and this merges them — **refusing to overwrite an existing key** and reporting every conflict. Tested against a key that already existed: rejected, existing value kept.

## The failures it encodes

These are why the file is worth reading rather than skimming:

- **Verification must be visual.** A section was reported as built because it measured 614px against the frame's 615px, and a scope doc independently agreed it existed. It shared nothing else with the design. A FAQ layout was reported as matching at 728 vs 727 while its media column rendered completely empty. Matching heights is not matching a design.
- **Three Liquid constructs that 500 every route and are invisible to Theme Check** — an output tag inside a string literal, a filter chain wrapped in `{% liquid %}` (Prettier reformats code *into* this shape), `{% raw %}` inside `{% comment %}`. Plus a 2-step `range`, which fails the whole theme upload.
- **Check what already exists before spawning.** Seven of that PDP's sections had already been delivered by the homepage build.

## Two rule fixes

Both were actively teaching the wrong thing:

- **`rules/snippets.md`** documented `@param name {Type} description`. Real LiquidDoc is `@param {type} name - description`, which all 45 of this theme's declarations use. The JSDoc form reads fine to a human and is **silently skipped** by `ValidDocParamTypes` — so a snippet documented that way has no validated parameter coverage at all.
- **`rules/sections.md`** presented two values as universal when they're contextual. The `750px` padding boilerplate is inherited from Dawn and 31 sections depend on it, so it stays — but component CSS is a separate decision, and this theme's `section-*.css` is split evenly between 750 and 769. And `.page-width` is right in Base while a client theme often has its own container; the two are frequently **identical at 1440**, so a section measured only at 1440 passes review and reads as broken on a large screen. That happened on a client build and was caught by the lead, not the developer.

The `.cursor/*.mdc` changes are generated by `sync-ai-config.sh` and have to travel with their sources or the pre-commit check fails.

## Known gap, not fixed here

Base's `.husky/pre-commit` **silently skips Theme Check** when the Shopify CLI can't start on the default Node — it reports "not blocking" and moves on. BPN's hook resolves a working Node from `~/.nvm` first. Worth porting, but it's a separate concern from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
